### PR TITLE
Support json as input and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Github action load_testplan
-This github action loads one or more yaml files, applying golang templating and
+This github action loads one or more yaml or json files, applying golang templating and
 merging them together to generate either environment variables or outputs to be
-used in github actions.
+used in github actions. It can also output yaml or json files containing the merged data.
 
 The code is maintained in the (development branch)[https://github.com/joernott/load_testplan/tree/development],
 the (main branch)[https://github.com/joernott/load_testplan/tree/main] only
@@ -27,6 +27,13 @@ The action has the following inputs:
 A comma separated list of yaml files to be parsed. You can use go template
 syntax in those files (see below). Files are parsed from left to right and
 content from later files overrides previous values.
+
+**input_type**: _Not required_, 'auto'  
+Set this to "yaml" and all the files specified in the _files_ parameter will be
+loaded as yaml files. Set it to "json" to always assume them to be json files.
+If this is set to "auto", it will try to determine the file type based on its
+suffix. Files ending in ".yml" or ".yaml" will be loaded as yaml, files with
+".json", ".jsn", ",jso" or ".js" will be loaded as json.
 
 **separator**: _Optional_, default: '_'  
 When flattening hierarchical yaml into key/value pairs, this separator will be
@@ -63,8 +70,12 @@ compile_flags='--foo'
 ```
 
 **yaml**: _Optional_, default: ''  
-If you provide a file name here, the merged and processed yaml will be written
-into the file. This helps debugging merge issues.
+If you provide a file name here, the merged and processed data will be written
+into the file as yaml. This helps debugging merge issues or can be used as later input.
+
+**json**: _Optional_, default: ''  
+If you provide a file name here, the merged and processed data will be written
+into the file as json. This helps debugging merge issues or can be used as later input.
 
 **logfile**: _Optional_, default: '-'  
 Tis defines where the actions log messages/output should go. The default "-"

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ inputs:
   files:
     description: 'Comma separated list of yaml files which will me merged from left to right'
     required: true
+  input_type:
+    description: 'Type of files to read, this can either be "auto", "yaml" or "json"'
+    required: false
+    default: 'auto'
   separator:
     description: 'Separator for chaining the yaml hierarch levels'
     required: false
@@ -22,6 +26,10 @@ inputs:
     default: false
   yaml:
     description: 'Output the final data structure as yaml file'
+    required: false
+    default: ''
+  json:
+    description: 'Output the final data structure as json file'
     required: false
     default: ''
   generate_output:

--- a/example/defaults.json
+++ b/example/defaults.json
@@ -1,0 +1,11 @@
+{
+    "string":"String",
+    "number":42,
+    "another_string":"Another string",
+    "root":{
+        "branch":{
+            "leaf":"A small leaf"
+        }
+    },
+    "array":["First","Second"]
+}

--- a/example/overwrite_string_with_array.json
+++ b/example/overwrite_string_with_array.json
@@ -1,0 +1,3 @@
+{
+    "another_string":["First","Second","Third"]
+}

--- a/example/overwrite_string_with_int.json
+++ b/example/overwrite_string_with_int.json
@@ -1,0 +1,3 @@
+{
+    "another_string":42
+}

--- a/example/overwrite_string_with_string.json
+++ b/example/overwrite_string_with_string.json
@@ -1,0 +1,3 @@
+{
+    "another_string":"Has been overwritten"
+}

--- a/example/overwrite_string_with_structure.json
+++ b/example/overwrite_string_with_structure.json
@@ -1,0 +1,7 @@
+{
+    "another_string":{
+        "array":["First","Second","Third"],
+        "number":42,
+        "string":"Another string"
+    }
+}

--- a/example/with_template.json
+++ b/example/with_template.json
@@ -1,0 +1,12 @@
+{
+    "string":"String",
+    "number":42,
+    "another_string":"Another string",
+    "root":{
+       "branch":{
+          "leaf":"A small leaf"
+       }
+    },
+    "template_string":"{{ .Github.Repository }}",
+    "path":"{{ .Env.INPUT_FILES }}"
+}

--- a/testplan/testplan.go
+++ b/testplan/testplan.go
@@ -12,14 +12,15 @@ import (
 	"fmt"
 
 	"encoding/json"
+	"net/http"
+	"net/url"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	githubactions "github.com/sethvargo/go-githubactions"
 	"gopkg.in/natefinch/lumberjack.v2"
 	"gopkg.in/yaml.v3"
-	"net/http"
-	"net/url"
 )
 
 // Input parameters for this action
@@ -95,7 +96,7 @@ func New() (*Testplan, error) {
 	x := plan.Actions.GetInput("input_type")
 	plan.InputType = strings.ToLower(x)
 	if plan.InputType == "" {
-		plan.InputType = "yaml"
+		plan.InputType = "auto"
 	}
 
 	err = plan.getFileList()
@@ -132,7 +133,7 @@ func New() (*Testplan, error) {
 	}
 	logger.Debug().
 		Array("files", a).
-		Str("input_type", plan.InputType).
+		Str("type", plan.InputType).
 		Str("separator", plan.Separator).
 		Bool("set_output", plan.SetOutput).
 		Bool("set_env", plan.SetEnv).
@@ -208,8 +209,23 @@ func (plan *Testplan) loadFiles() error {
 		}
 
 		var data map[string]interface{}
+		t := plan.InputType
+		if t == "auto" {
+			s := strings.Split(f, ".")
+			suffix := s[len(s)-1]
+			switch suffix {
+			case "json", "jso", "jsn", "js":
+				t = "json"
+			case "yaml", "yml":
+				t = "yaml"
+			default:
+				err := errors.New("Unkonwn file suffix " + suffix + ". Can't use input type 'auto'.")
+				log.Error().Err(err).Str("file", f).Str("suffix", suffix).Msg("Can't determine file type")
+				return err
+			}
+		}
 
-		switch plan.InputType {
+		switch t {
 		case "json":
 			err = json.Unmarshal(input, &data)
 			if err != nil {
@@ -262,39 +278,43 @@ func getFromURL(url string) (string, error) {
 func (plan *Testplan) parseFile(name string) ([]byte, error) {
 	logger := log.With().Str("func", "readFile").Str("package", "testplan").Logger()
 	logger.Trace().Msg("Enter func")
+	var raw string
 	var b bytes.Buffer
 	var t *template.Template
+	var template_name string
 
 	u, err := url.ParseRequestURI(name)
 	if err != nil || u.Scheme == "file" {
-		t = template.New(path.Base(name))
-		t, err = t.ParseFiles(name)
+		s, err := os.ReadFile(name)
+		template_name = path.Base(name)
+		raw = string(s)
 		if err != nil {
 			log.Error().Err(err).Str("file", name).Msg("Failed to read file")
 			return b.Bytes(), err
 		}
 	} else {
+		template_name = path.Base(u.Path)
 		n := name
 		if plan.Token != "" {
 			n = n + "?token=" + plan.Token
 			log.Debug().Msg("Adding token to url")
 		}
-		s, err1 := getFromURL(n)
-		if err1 != nil {
-			return b.Bytes(), err1
-		}
-		t = template.New(path.Base(u.Path))
-		t, err1 = t.Parse(s)
-		if err1 != nil {
-			log.Error().Err(err).Str("file", name).Msg("Failed to parse template from URL")
-			return b.Bytes(), err1
+		raw, err = getFromURL(n)
+		if err != nil {
+			return b.Bytes(), err
 		}
 	}
-
-	if err = t.Execute(&b, plan); err != nil {
+	t = template.New(template_name)
+	t, err = t.Parse(raw)
+	if err != nil {
 		log.Error().Err(err).Str("file", name).Msg("Failed to parse template")
 		return b.Bytes(), err
 	}
+	if err = t.Execute(&b, plan); err != nil {
+		log.Error().Err(err).Str("file", name).Msg("Failed to execute template")
+		return b.Bytes(), err
+	}
+	log.Trace().Str("raw", raw).Str("parsed", string(b.Bytes())).Msg("Parsed file")
 	return b.Bytes(), nil
 }
 
@@ -328,12 +348,12 @@ func (plan *Testplan) Output() error {
 		}
 		plan.jsonfile = f
 		defer plan.jsonfile.Close()
-		j, err := json.Marshal(plan.Data)
+		j, err := json.MarshalIndent(plan.Data, "", "    ")
 		if err != nil {
 			logger.Warn().Err(err).Str("file", plan.JsonName).Msg("Can't marshal json, skipping json output")
 			return err
 		}
-		fmt.Fprintf(plan.jsonfile, string(j))
+		fmt.Fprint(plan.jsonfile, string(j))
 	}
 
 	err := plan.OutputJob()

--- a/testplan/testplan.go
+++ b/testplan/testplan.go
@@ -55,13 +55,13 @@ jobs:
         uses: 'joernott/load_testplan@v1'
         with:
           files: '{{ range $i, $file := .Files }}{{ if gt $i 0 }},{{ end }}{{ $file }}{{ end }}'
-		  input_type: '{{ .InputType }}'
+          input_type: '{{ .InputType }}'
           separator: '{{ .Separator }}'
           set_output: {{ .SetOutput }}
           set_env: {{ .SetEnv }}
           set_print: {{ .SetPrint }}
           yaml: '{{ .YamlName }}'
-		  json: '{{ .JsonName }}'
+          json: '{{ .JsonName }}'
           loglevel: '{{ .LogLevel }}'
           logfile: '{{ .LogFile }}'
     outputs:

--- a/testplan/testplan_test.go
+++ b/testplan/testplan_test.go
@@ -354,7 +354,7 @@ func TestOutput(t *testing.T) {
 		}
 		var data map[string]interface{}
 		if err := yaml.Unmarshal(b, &data); err != nil {
-			t.Errorf("Could not unmarshall yaml, reason: %v", err)
+			t.Errorf("Could not unmarshall yaml, reason: %v, data %v ", err, string(b))
 		}
 		j, ok := data["jobs"].(map[string]interface{})
 		if !ok {


### PR DESCRIPTION
We can now feed both yaml and json files to load_testplan. A new parameter "input_type" can be set to "yaml" to expect those files to contain yaml data, "json" to expect those files to contain json data or "auto" to guess the type by looking at the file suffix.

A new output "json" allows to write the merged data in json format as well.